### PR TITLE
Visibility

### DIFF
--- a/src/Dreamer/Model.java
+++ b/src/Dreamer/Model.java
@@ -26,6 +26,7 @@ public class Model extends Element {
 	void add() {
 		for (Shape3d s : models) {
 			s.recenter();
+			// System.out.println(s.position);
 			s.add();
 		}
 	}

--- a/src/Dreamer/Model.java
+++ b/src/Dreamer/Model.java
@@ -5,23 +5,28 @@ import java.util.ArrayList;
 import org.lwjgl.util.vector.Vector3f;
 
 public class Model extends Element {
-    private static final long serialVersionUID = 1L;
+
+	private static final long serialVersionUID = 1L;
 	private ArrayList<Shape3d> models;
 	private ArrayList<Vector3f> lights;
-	
+
 	Model(String s, int scale, int x, int y, int z) {
 		models = Library.getModel(s, scale, x, y, z);
 		lights = Library.getModelLights(s, scale, x, y, z);
 		if (lights.size() > 0)
 			addLights();
 	}
+
 	public void addLights() {
 		for (Vector3f v : lights)
 			new Lamp(v.x, v.y, v.z, 500).add();
 	}
+
 	@Override
 	void add() {
-		for (Shape3d s : models)
+		for (Shape3d s : models) {
+			s.recenter();
 			s.add();
+		}
 	}
 }

--- a/src/Dreamer/Positionable.java
+++ b/src/Dreamer/Positionable.java
@@ -18,8 +18,8 @@ public class Positionable extends Element {
 		String s = getClass().toString() + "@";
 		s = s.concat("(" + (int) position.x);
 		s = s.concat(", " + (int) position.y + ") ");
-		s = s.concat(" w " + (int) width);
-		s = s.concat(" h " + (int) height);
+		s = s.concat(" w " + (int) getWidth());
+		s = s.concat(" h " + (int) getHeight());
 		return s;
 	}
 	

--- a/src/Dreamer/Shape3d.java
+++ b/src/Dreamer/Shape3d.java
@@ -63,48 +63,45 @@ public class Shape3d extends Positionable implements Lightable {
 
 	@Override
 	boolean isVisible() {
-		boolean huehuehue = false;
-
-		if (!huehuehue) {
-			if (Camera.isPointVisible(getX(), getY(), getZ()))
-				return true;
-
-			if (getX() >= Camera.getCenterX() && getY() >= Camera.getCenterY()) // Cartesian
-																				// I
-				if (Camera.isPointVisible(getX() - getWidth() / 2, getY()
-						- getHeight() / 2, getZ() - getDepth()))
-					return true;
-				else
-					return false;
-
-			if (getX() <= Camera.getCenterX() && getY() >= Camera.getCenterY()) // Cartesian
-																				// II
-				if (Camera.isPointVisible(getX() + getWidth() / 2, getY()
-						- getHeight() / 2, getZ() - getDepth()))
-					return true;
-				else
-					return false;
-
-			if (getX() <= Camera.getCenterX() && getY() <= Camera.getCenterY()) // Cartesian
-																				// III
-				if (Camera.isPointVisible(getX() + getWidth() / 2, getY()
-						+ getHeight() / 2, getZ() - getDepth()))
-					return true;
-				else
-					return false;
-
-			if (getX() >= Camera.getCenterX() && getY() <= Camera.getCenterY()) // Cartesian
-																				// IV
-				if (Camera.isPointVisible(getX() - getWidth() / 2, getY()
-						+ getHeight() / 2, getZ() - getDepth()))
-					return true;
-				else
-					return false;
-
-			return false;
-		} else {
+		if(getWidth() > Constants.screenWidth)
 			return true;
-		}
+
+		if (Camera.isPointVisible(getX(), getY(), getZ()))
+			return true;
+
+		if (getX() >= Camera.getCenterX() && getY() >= Camera.getCenterY()) // Cartesian
+																			// I
+			if (Camera.isPointVisible(getX() - getWidth() / 2, getY()
+					- getHeight() / 2, getZ() - getDepth()))
+				return true;
+			else
+				return false;
+
+		if (getX() <= Camera.getCenterX() && getY() >= Camera.getCenterY()) // Cartesian
+																			// II
+			if (Camera.isPointVisible(getX() + getWidth() / 2, getY()
+					- getHeight() / 2, getZ() - getDepth()))
+				return true;
+			else
+				return false;
+
+		if (getX() <= Camera.getCenterX() && getY() <= Camera.getCenterY()) // Cartesian
+																			// III
+			if (Camera.isPointVisible(getX() + getWidth() / 2, getY()
+					+ getHeight() / 2, getZ() - getDepth()))
+				return true;
+			else
+				return false;
+
+		if (getX() >= Camera.getCenterX() && getY() <= Camera.getCenterY()) // Cartesian
+																			// IV
+			if (Camera.isPointVisible(getX() - getWidth() / 2, getY()
+					+ getHeight() / 2, getZ() - getDepth()))
+				return true;
+			else
+				return false;
+
+		return false;
 	}
 
 	Shape3d scale(float f) { return scale(f, f, f); }
@@ -170,7 +167,7 @@ public class Shape3d extends Positionable implements Lightable {
 	}
 
 	Vector3f findCenter() {
-		// TODO: this!
+
 		Vector3f center = new Vector3f();
 
 		for (Vector3f v : vertices) {
@@ -178,7 +175,6 @@ public class Shape3d extends Positionable implements Lightable {
 		}
 
 		center.scale(1.0f / (float)vertices.size());
-		System.out.println(center + ", " + position);
 		return center;
 	}
 	

--- a/src/Dreamer/Shape3d.java
+++ b/src/Dreamer/Shape3d.java
@@ -107,16 +107,7 @@ public class Shape3d extends Positionable implements Lightable {
 		}
 	}
 
-	Shape3d scale(float f) {
-
-		for (Vector3f v : this.vertices) {
-			v.scale(f);
-		}
-
-		manhattanRadius.scale(f);
-
-		return this;
-	}
+	Shape3d scale(float f) { return scale(f, f, f); }
 
 	Shape3d scale(float x, float y, float z) {
 
@@ -186,9 +177,20 @@ public class Shape3d extends Positionable implements Lightable {
 			center = Vector3f.add(center, v, center);
 		}
 
-		center.scale(1 / vertices.size());
-
+		center.scale(1.0f / (float)vertices.size());
+		System.out.println(center + ", " + position);
 		return center;
+	}
+	
+	Shape3d recenter() {
+		Vector3f c = findCenter();
+		manhattanRadius.set(0, 0, 0);
+		for(Vector3f v: vertices) {
+			Vector3f.sub(v, c, v);
+			updateBounds(v, manhattanRadius);
+		}
+		setPosition(c);
+		return this;
 	}
 
 	public ArrayList<Vector2f> generateIntersectionPoints() {


### PR DESCRIPTION
I know what the issues were, instituted one temporary and one permanent fix.

Issue 1: All Shape3ds made by ObjLoader had centres at 0,0,0 and massive height and widths.  
Solution 1: Method to automatically recenter and recalculate the width and height of Shape3ds created and instituted for all models upon addition to game environment.

Issue 2: When designing Shape3d.isVisible(), we were considering terrain in strips or objects broken up into smallish pieces, but the terrain in Dusk levels is one large piece that is several times the screen size.  The isVisible() method can't handle objects that are so big that when their centre is offscreen their corner that extends past the screen in the direction of it is ALSO offscreen (objects bigger than 2x the screensize in one direction)
Temp fix 2: If something is really wide, always display it.  Since there is only one of these per Dusk level that should not be too intensive for now, but the long-term solution is the same as problems with any really large objects as before: all really huge things can be made up of smaller Shape3ds, either by design or auto-splitting them as in previous terrain methods.  Not a priority at the moment though I think.